### PR TITLE
Completables

### DIFF
--- a/src/main/java/com/artipie/conan/Completables.java
+++ b/src/main/java/com/artipie/conan/Completables.java
@@ -57,11 +57,11 @@ public final class Completables {
          * Initializes instance with the List of CompletableFutures.
          * @param futures List of CompletableFutures to process.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+        @SuppressWarnings("rawtypes")
         public ForList(final List<CompletableFuture<T>> futures) {
-            @SuppressWarnings("rawtypes") final CompletableFuture[] arr = futures
-                .toArray(new CompletableFuture[0]);
-            this.alls = CompletableFuture.allOf(arr);
+            this.alls = CompletableFuture.allOf(
+                futures.toArray(new CompletableFuture[0])
+            );
             this.futures = futures;
         }
 
@@ -110,11 +110,10 @@ public final class Completables {
          * Initializes instance with the List of Tuples with CompletableFuture.
          * @param futures List of Tuples with CompletableFuture.
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         public ForTuples(final List<Tuple2<K, CompletableFuture<V>>> futures) {
-            @SuppressWarnings("rawtypes") final CompletableFuture[] arr = futures
-                .stream().map(Tuple2::_2).toArray(CompletableFuture[]::new);
-            this.alls = CompletableFuture.allOf(arr);
+            this.alls = CompletableFuture.allOf(
+                futures.stream().map(Tuple2::_2).toArray(CompletableFuture[]::new)
+            );
             this.futures = futures;
         }
 

--- a/src/main/java/com/artipie/conan/Completables.java
+++ b/src/main/java/com/artipie/conan/Completables.java
@@ -89,7 +89,7 @@ public final class Completables {
     }
 
     /**
-     * Coverts List of CompletableFutures to CompletableFuture providing list of Tuples.
+     * Coverts List of Tuples with CompletableFutures to CompletableFuture providing list of Tuples.
      * @param <K> Key type for the CompletableFuture result value.
      * @param <V> Type of the result value.
      * @since 0.1

--- a/src/main/java/com/artipie/conan/Completables.java
+++ b/src/main/java/com/artipie/conan/Completables.java
@@ -46,7 +46,7 @@ public final class Completables {
         /**
          * CompletableFuture to wait for all items.
          */
-        private final CompletableFuture<Void>  alls;
+        private final CompletableFuture<Void> alls;
 
         /**
          * List of CompletableFutures to process.
@@ -99,7 +99,7 @@ public final class Completables {
         /**
          * CompletableFuture to wait for all items.
          */
-        private final CompletableFuture<Void>  alls;
+        private final CompletableFuture<Void> alls;
 
         /**
          * List of Tuples with CompletableFuture.

--- a/src/main/java/com/artipie/conan/Completables.java
+++ b/src/main/java/com/artipie/conan/Completables.java
@@ -41,7 +41,7 @@ public final class Completables {
      * @param <T> Type of the results.
      * @since 0.1
      */
-    public static final class ForList<T> {
+    public static final class JoinList<T> {
 
         /**
          * CompletableFuture to wait for all items.
@@ -58,7 +58,7 @@ public final class Completables {
          * @param futures List of CompletableFutures to process.
          */
         @SuppressWarnings("rawtypes")
-        public ForList(final List<CompletableFuture<T>> futures) {
+        public JoinList(final List<CompletableFuture<T>> futures) {
             this.alls = CompletableFuture.allOf(
                 futures.toArray(new CompletableFuture[0])
             );
@@ -94,7 +94,7 @@ public final class Completables {
      * @param <V> Type of the result value.
      * @since 0.1
      */
-    public static final class ForTuples<K, V> {
+    public static final class JoinTuples<K, V> {
 
         /**
          * CompletableFuture to wait for all items.
@@ -110,7 +110,7 @@ public final class Completables {
          * Initializes instance with the List of Tuples with CompletableFuture.
          * @param futures List of Tuples with CompletableFuture.
          */
-        public ForTuples(final List<Tuple2<K, CompletableFuture<V>>> futures) {
+        public JoinTuples(final List<Tuple2<K, CompletableFuture<V>>> futures) {
             this.alls = CompletableFuture.allOf(
                 futures.stream().map(Tuple2::_2).toArray(CompletableFuture[]::new)
             );

--- a/src/main/java/com/artipie/conan/Completables.java
+++ b/src/main/java/com/artipie/conan/Completables.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.conan;
+
+import io.vavr.Tuple2;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Encapsulates handling of collections of CompletableFutures.
+ * Here CompletableFuture::join() won't block since it's used after CompletableFuture.allOf().
+ * @since 0.1
+ */
+public final class Completables {
+
+    /**
+     * Private ctor. Static methods only.
+     */
+    private Completables() {
+    }
+
+    /**
+     * Returns CompletableFuture with extracted results from all CompletableFutures in the List.
+     * @param futures List of CompletableFuture objects to wait & collect result.
+     * @param <T> Type of the data for CompletableFuture.
+     * @return CompletableFuture with the List of results.
+     */
+    public static <T> CompletableFuture<List<T>> forItems(
+        final List<CompletableFuture<T>> futures
+    ) {
+        @SuppressWarnings("rawtypes") final CompletableFuture[] arr = futures
+            .toArray(new CompletableFuture[0]);
+        return CompletableFuture.allOf(arr).thenApply(
+            nothing -> futures.stream().map(CompletableFuture::join).collect(Collectors.toList())
+        );
+    }
+
+    /**
+     * Returns CompletableFuture with extracted results from all CompletableFutures in the tuples.
+     * @param futures List of Tuples of Key + its CompletableFuture.
+     * @param <K> Type of the key.
+     * @param <V> Type of the value, CompletableFuture result.
+     * @return CompletableFuture with the List of Tuples with K & V directly.
+     */
+    public static <K, V> CompletableFuture<List<Tuple2<K, V>>> forTuples(
+        final List<Tuple2<K, CompletableFuture<V>>> futures
+    ) {
+        @SuppressWarnings("rawtypes") final CompletableFuture[] arr = futures
+            .stream().map(Tuple2::_2).toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(arr).thenApply(
+            nothing -> futures.stream().map(
+                tuple -> new Tuple2<>(tuple._1(), tuple._2().join())
+            ).collect(Collectors.toList())
+        );
+    }
+}


### PR DESCRIPTION
Classes for Collecting results from multiple CompletableFutures. They will be used in both, SDK & Protocol parts, and keep join()-s and unchecked operations in single place.
Note that in this push request CompletableFuture.join() won't block, since it's used after CompletableFuture.allOf().

At first I implemented it as utility class, but then I found out that it's prohibited by qulice, so I ended up implementing it as several classes.
I keep original implementation in the first commit for the reference.


